### PR TITLE
Composer, drush si, should run during prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,12 +6,13 @@ tasks:
     init: |
       docker build -t devwithlando/php:8.0-apache-4 .
       docker build -t devwithlando/phpmyadmin:5.1.1 .
-    command: |
       lando start
       lando composer require drush/drush
       lando composer install
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
+    command: |
+      lando start
       gp preview $(gp url $(lando info --format=json | jq -r ".[0].urls[0]" | sed -e 's#http://localhost:\(\)#\1#'))
   
 ports:


### PR DESCRIPTION
Whatever setup can run during prebuild would provide a nicer experience for the user.

<a href="https://gitpod.io/#https://github.com/lando/drupal-dev-environment/pull/2"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

