### PR TITLE
Temporary fix for network issues inside lando container (in Gitpod)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
     command: |
       # start a rebuild  with actual networking service (prebuild uses different)
-      lando rebuild
+      lando rebuild -y
       gp preview $(gp url $(lando info --format=json | jq -r ".[0].urls[0]" | sed -e 's#http://localhost:\(\)#\1#'))
 ports:
   - port: 3306

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,18 +4,13 @@ image: devwithlando/gitpod:1
 tasks:
   - name: Setup Drupal Dev Env
     init: |
-      ### commennt this out if you are not running from prebuild
-      docker build -t devwithlando/php:8.0-apache-4 .
-      docker build -t devwithlando/phpmyadmin:5.1.1 .
-      ###
-    command: |
       lando start
       lando composer require drush/drush
       lando composer install
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
+    command: |
       gp preview $(gp url $(lando info --format=json | jq -r ".[0].urls[0]" | sed -e 's#http://localhost:\(\)#\1#'))
-  
 ports:
   - port: 3306
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,7 +27,7 @@ ports:
 github:
   prebuilds:
     master: true
-    branches: false
+    branches: true
     pullRequests: true
     pullRequestsFromForks: true
     addCheck: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,8 @@ tasks:
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
     command: |
+      # start a rebuild  with actual networking service (prebuild uses different)
+      lando rebuild
       gp preview $(gp url $(lando info --format=json | jq -r ".[0].urls[0]" | sed -e 's#http://localhost:\(\)#\1#'))
 ports:
   - port: 3306

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,16 +4,16 @@ image: devwithlando/gitpod:1
 tasks:
   - name: Setup Drupal Dev Env
     init: |
-      # commennt this out if you are not running from prebuild
+      ### commennt this out if you are not running from prebuild
       docker build -t devwithlando/php:8.0-apache-4 .
       docker build -t devwithlando/phpmyadmin:5.1.1 .
+      ###
+    command: |
       lando start
-      lando composer require drush/drush 
+      lando composer require drush/drush
       lando composer install
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
-    command: |
-      lando start
       gp preview $(gp url $(lando info --format=json | jq -r ".[0].urls[0]" | sed -e 's#http://localhost:\(\)#\1#'))
   
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,14 +4,13 @@ image: devwithlando/gitpod:1
 tasks:
   - name: Setup Drupal Dev Env
     init: |
-      docker build -t devwithlando/php:8.0-apache-4 .
-      docker build -t devwithlando/phpmyadmin:5.1.1 .
-    command: |
       lando start
       lando composer require drush/drush
       lando composer install
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
+    command: |
+      lando start
       gp preview $(gp url $(lando info --format=json | jq -r ".[0].urls[0]" | sed -e 's#http://localhost:\(\)#\1#'))
   
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,9 +4,12 @@ image: devwithlando/gitpod:1
 tasks:
   - name: Setup Drupal Dev Env
     init: |
+      # commennt this out if you are not running from prebuild
+      docker build -t devwithlando/php:8.0-apache-4 .
+      docker build -t devwithlando/phpmyadmin:5.1.1 .
       lando start
-      lando composer require drush/drush --quiet
-      lando composer install --quiet
+      lando composer require drush/drush 
+      lando composer install
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,8 +5,8 @@ tasks:
   - name: Setup Drupal Dev Env
     init: |
       lando start
-      lando composer require drush/drush
-      lando composer install
+      lando composer require drush/drush --quiet
+      lando composer install --quiet
       chmod ug+w -R /workspace/drupal-dev-environment/sites/default/
       lando drush si -y --account-pass=admin --site-name='lando_drupal9' --db-url=mysql://drupal9:drupal9@database/drupal9 demo_umami
     command: |

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,5 +1,7 @@
 name: lando-d9
 recipe: drupal9
+compose:
+  - docker-compose.network-mtu.yml
 config:
   webroot: .
 

--- a/.lando.yml
+++ b/.lando.yml
@@ -7,9 +7,6 @@ config:
 services:
   appserver:
     ssl: false
-    build:
-      - composer install --quiet
-
   phpmyadmin:
     type: phpmyadmin
     hosts:

--- a/.lando.yml
+++ b/.lando.yml
@@ -4,10 +4,12 @@ compose:
   - docker-compose.network-mtu.yml
 config:
   webroot: .
-
 services:
   appserver:
     ssl: false
+    build:
+      - composer install --quiet
+
   phpmyadmin:
     type: phpmyadmin
     hosts:

--- a/docker-compose.network-mtu.yml
+++ b/docker-compose.network-mtu.yml
@@ -7,10 +7,6 @@
 # Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
 # and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
 #
-# ddev doesn't use Gitpod's custom docker-compose binary. Instead, ddev uses
-# its own docker-compose binary at /home/gitpod/.ddev/bin/docker-compose
-# ddev issue [WIP] - https://github.com/drud/ddev/issues/3766
-#
 # Align the MTU value to the one that is set in Gitpod (1440)
 networks:
   default:

--- a/docker-compose.network-mtu.yml
+++ b/docker-compose.network-mtu.yml
@@ -1,0 +1,18 @@
+# Source: https://github.com/shaal/ddev-gitpod/blob/main/.ddev/docker-compose.network-mtu.yaml
+# Temporary fix for network issues when running composer inside lando container (in Gitpod)
+#
+# Since Gitpod removed slirp4netns as part of performance improvements,
+# MTU value should be aligned to the one in gitpod.io
+#
+# Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
+# and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
+#
+# ddev doesn't use Gitpod's custom docker-compose binary. Instead, ddev uses
+# its own docker-compose binary at /home/gitpod/.ddev/bin/docker-compose
+# ddev issue [WIP] - https://github.com/drud/ddev/issues/3766
+#
+# Align the MTU value to the one that is set in Gitpod (1440)
+networks:
+  default:
+    driver_opts:
+      com.docker.network.driver.mtu: 1440


### PR DESCRIPTION
### issue:
Since Gitpod changed MTU from 1500 to 1440, MTU value should be aligned to the one in gitpod.io

added **docker-compose.network-mtu.yml** with MTU 1440: 
```
networks:
  default:
    driver_opts:
      com.docker.network.driver.mtu: 1440
```


and call it in .lando.yml with:
```
name: lando-d9
recipe: drupal9
compose:
  - docker-compose.network-mtu.yml
 
[...]
```
### Test:
Start this example workspace in gitpod, lando ssh and try to curl -o some example stuff..  

### Gitpod

<a href="https://gitpod.io/#https://github.com/lando/drupal-dev-environment/pull/4"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

